### PR TITLE
Travis fix1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,8 @@ script:
   - export REPO=$(echo ${TRAVIS_REPO_SLUG} | awk '{gsub(/\./,"_",$0);print tolower($0)}')
   - export REPO=${REPO/robbie1977/rcourt}
   - export TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi`
-  - sed -i "s|http://www.virtualflybrain.org/owl/vfb.owl|${OWLURL}|g" Dockerfile
-  - sed -i "s|http://www.virtualflybrain.org/owl/vfb.owl|${OWLURL}|g" application.conf
   - echo -e "travis_fold:end:Geppetto-Config"
-  - docker build -f Dockerfile -t $REPO:$VFBSUB --build-arg CONF_REPO=https://github.com/VirtualFlyBrain/vfb-pipeline-config.git --build-arg CONF_BRANCH=prod . 
+  - docker build -f Dockerfile -t $REPO:$VFBSUB --build-arg OWLURL="${OWLURL}" --build-arg CONF_REPO=https://github.com/VirtualFlyBrain/vfb-pipeline-config.git --build-arg CONF_BRANCH=prod . 
   - |
     if [ "$VFBSUB" != "local" ]; then
       docker tag $REPO:$VFBSUB $REPO:$TAG-$VFBSUB

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - export REPO=${REPO/robbie1977/rcourt}
   - export TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi`
   - echo -e "travis_fold:end:Geppetto-Config"
-  - docker build -f Dockerfile -t $REPO:$VFBSUB --build-arg OWLURL="${OWLURL}" --build-arg CONF_REPO=https://github.com/VirtualFlyBrain/vfb-pipeline-config.git --build-arg CONF_BRANCH=prod . 
+  - docker build -f Dockerfile -t $REPO:$VFBSUB --build-arg OWLURL_ARG="${OWLURL}" --build-arg CONF_REPO=https://github.com/VirtualFlyBrain/vfb-pipeline-config.git --build-arg CONF_BRANCH=prod . 
   - |
     if [ "$VFBSUB" != "local" ]; then
       docker tag $REPO:$VFBSUB $REPO:$TAG-$VFBSUB

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,11 @@ MAINTAINER Robbie - Virtual Fly Brain <rcourt@ed.ac.uk>
 # from compose args
 ARG CONF_REPO
 ARG CONF_BRANCH
+ARG OWLURL_ARG
 
 ENV CONF_BASE=/opt/conf_base
 ENV CONF_DIR=${CONF_BASE}/config/owlery
+ENV OWLURL=$OWLURL_ARG
 
 USER root
 

--- a/startup.sh
+++ b/startup.sh
@@ -8,7 +8,7 @@ source ${CONF_DIR}/config.env
 
 cp -v ${CONF_DIR}/application.conf /srv/conf/
 
-sed -i s|location.*\"|location\ =\ "${OWLURL}"|g /srv/conf/application.conf
+sed -i "s|location.*\"|location\ =\ \"${OWLURL}\"|g" /srv/conf/application.conf
 
 cat /srv/conf/application.conf
 

--- a/startup.sh
+++ b/startup.sh
@@ -8,7 +8,7 @@ source ${CONF_DIR}/config.env
 
 cp -v ${CONF_DIR}/application.conf /srv/conf/
 
-sed -i s|location.*"|location\ =\ "${OWLURL}"|g /srv/conf/application.conf
+sed -i s|location.*\"|location\ =\ "${OWLURL}"|g /srv/conf/application.conf
 
 cat /srv/conf/application.conf
 

--- a/startup.sh
+++ b/startup.sh
@@ -8,7 +8,7 @@ source ${CONF_DIR}/config.env
 
 cp -v ${CONF_DIR}/application.conf /srv/conf/
 
-sed -i "s|http://www.virtualflybrain.org/owl/vfb.owl|${OWLURL}|g" /srv/conf/application.conf
+sed -i s|location.*"|location\ =\ "${OWLURL}"|g /srv/conf/application.conf
 
 cat /srv/conf/application.conf
 


### PR DESCRIPTION
It was just the removal of the config file that was messing up travis sed function: 
```
[0K$ sed -i "s|http://www.virtualflybrain.org/owl/vfb.owl|${OWLURL}|g" application.conf
sed: can't read application.conf: No such file or directory
travis_time:end:00d1efd0:start=1612862713309289231,finish=1612862713316499030,duration=7209799,event=script
[0K[31;1mThe command "sed -i "s|http://www.virtualflybrain.org/owl/vfb.owl|${OWLURL}|g" application.conf" exited with 2.[0m
travis_time:start:00a6ddee
```
I've added a more generic method to pass the various versions compiled by travis.